### PR TITLE
Add a warning regarding ModemManager to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ To program the module:
 
     $ iceFUNprog blinky.bin
 
+Note: in case the programmer doesn't seem to do anything, make sure you are not accidentally
+running software which tries to use your device as a modem 
+(e.g. [ModemManager](https://www.freedesktop.org/wiki/Software/ModemManager/)) as this 
+interferes with this programmer.


### PR DESCRIPTION
It took me a few hours to figure out why the programmer wasn't able to program my device. Apparently my system (Ubuntu 19.04, which by default has ModemManager installed) expects all USB ACM devices to be modems.

I suggest to add a small note to the readme to help people out who ran into the same issue.