### PR TITLE
check arguments before opening serial port

### DIFF
--- a/iceFUNprog.c
+++ b/iceFUNprog.c
@@ -128,15 +128,6 @@ struct termios config;
 	}
 	closedir(d);
 
-	fd = open(portName, O_RDWR | O_NOCTTY);
-	if(fd == -1) {
-		fprintf(stderr, "%s: failed to open serial port.\n", argv[0]);
-		return EXIT_FAILURE;
-	}
-	tcgetattr(fd, &config);
-	cfmakeraw(&config);								// set options for raw data
-	tcsetattr(fd, TCSANOW, &config);
-
 /* Decode command line parameters */
 	static struct option long_options[] = {
 		{"help", no_argument, NULL, -2},
@@ -178,6 +169,16 @@ struct termios config;
 			return EXIT_FAILURE;
 		}
 	}
+
+	fd = open(portName, O_RDWR | O_NOCTTY);
+	if(fd == -1) {
+		fprintf(stderr, "%s: failed to open serial port.\n", argv[0]);
+		return EXIT_FAILURE;
+	}
+	tcgetattr(fd, &config);
+	cfmakeraw(&config);								// set options for raw data
+	tcsetattr(fd, TCSANOW, &config);
+
 	if (optind + 1 == argc) {
 		filename = argv[optind];
 	} else if (optind != argc) {


### PR DESCRIPTION
Fixes #5 and also fixes another issue where the program ignores the specified port because it does not check the arguments before opening the port.

Example:

```
$ iceFUNprog -P /dev/ttyACM2 build/blinky.bin
iceFUN v1, Flash ID 1F 85 01
Erasing sector 000000
Erasing sector 010000
Erasing sector 020000
file size: 135100
Programming ....................................................
Verifying ....................................................
Done.
```

This should fail because there is no /dev/ttyACM2 on my computer. With this fix:

```
$ iceFUNprog -P /dev/ttyACM2 build/blinky.bin   
iceFUNprog: failed to open serial port.
```

And `-h` works normally as expected even when there are no serial ports attached or you don't have permissions, displays the help menu at least.